### PR TITLE
Set AlignConsecutiveDeclarations to false and SpacesBeforeTrailingComments to 2

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: true
 AlignConsecutiveBitFields: true
-AlignConsecutiveDeclarations: true
+AlignConsecutiveDeclarations: false
 AlignConsecutiveMacros: true
 AlignEscapedNewlines: Left
 AlignOperands: Align
@@ -109,7 +109,7 @@ PenaltyBreakFirstLessLess: 120
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 60
+PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
 ReflowComments: true
 SortIncludes: true

--- a/.clang-format
+++ b/.clang-format
@@ -126,7 +126,7 @@ SpaceBeforeRangeBasedForLoopColon: false
 SpaceBeforeSquareBrackets: false
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 4
+SpacesBeforeTrailingComments: 2
 SpacesInAngles: false
 SpacesInConditionalStatement: false
 SpacesInContainerLiterals: false

--- a/include/freertos_tasks_c_additions.h
+++ b/include/freertos_tasks_c_additions.h
@@ -26,7 +26,7 @@ extern "C" {
  */
 TickType_t GetExpectedIdleTime(void)
 {
-    TickType_t  xReturn;
+    TickType_t xReturn;
     UBaseType_t uxHigherPriorityReadyTasks = pdFALSE;
 
     /* uxHigherPriorityReadyTasks takes care of the case where

--- a/include/rtc.h
+++ b/include/rtc.h
@@ -22,14 +22,14 @@ extern "C" {
 #include "stm32l4xx_hal.h"
 
 /* Functions -----------------------------------------------------------------*/
-void     RtcInit(void);
+void RtcInit(void);
 uint32_t RtcGetEpoch(void);
-void     RtcConvertEpochToDatetime(uint32_t         epoch,
-                                   RTC_DateTypeDef* date,
-                                   RTC_TimeTypeDef* time);
-uint8_t  RtcSetAlarmFromEpoch(const uint32_t epoch);
-void     RtcDeactivateAlarm(void);
-void     RtcWaitForClockSynchronization(void);
+void RtcConvertEpochToDatetime(uint32_t epoch,
+                               RTC_DateTypeDef* date,
+                               RTC_TimeTypeDef* time);
+uint8_t RtcSetAlarmFromEpoch(const uint32_t epoch);
+void RtcDeactivateAlarm(void);
+void RtcWaitForClockSynchronization(void);
 
 #ifdef __cplusplus
 }

--- a/include/scheduler.h
+++ b/include/scheduler.h
@@ -59,11 +59,11 @@ typedef struct
 } Scheduler_t;
 
 /* Functions -----------------------------------------------------------------*/
-void    SchedulerInit(void);
+void SchedulerInit(void);
 uint8_t SchedulerAddJob(const uint32_t period, const Callback_t callback);
-void    SchedulerProcess(void);
-void    SchedulerExecutePendingJobs(void);
-void    SchedulerStop(void);
+void SchedulerProcess(void);
+void SchedulerExecutePendingJobs(void);
+void SchedulerStop(void);
 
 #ifdef __cplusplus
 }

--- a/source/hardware.c
+++ b/source/hardware.c
@@ -24,9 +24,9 @@
  */
 void SystemClockConfig(void)
 {
-    RCC_OscInitTypeDef       RCC_OscInitStruct = {0U};
-    RCC_ClkInitTypeDef       RCC_ClkInitStruct = {0U};
-    RCC_PeriphCLKInitTypeDef PeriphClkInit     = {0U};
+    RCC_OscInitTypeDef RCC_OscInitStruct   = {0U};
+    RCC_ClkInitTypeDef RCC_ClkInitStruct   = {0U};
+    RCC_PeriphCLKInitTypeDef PeriphClkInit = {0U};
 
     __HAL_RCC_SYSCFG_CLK_ENABLE();
     __HAL_RCC_PWR_CLK_ENABLE();

--- a/source/main.c
+++ b/source/main.c
@@ -39,7 +39,7 @@ void JobShortPeriodCallback(void);
 void JobLongPeriodCallback(void);
 
 /* External functions --------------------------------------------------------*/
-extern TickType_t  GetExpectedIdleTime(void);
+extern TickType_t GetExpectedIdleTime(void);
 extern UBaseType_t IsDelayedTaskListEmpty(void);
 
 /**

--- a/source/rtc.c
+++ b/source/rtc.c
@@ -85,8 +85,8 @@ uint32_t RtcGetEpoch(void)
 {
     RTC_DateTypeDef date;
     RTC_TimeTypeDef time;
-    struct tm       dateTime;
-    static time_t   epoch;
+    struct tm dateTime;
+    static time_t epoch;
 
     HAL_RTC_GetTime(&hrtc, &time, RTC_FORMAT_BIN);
     HAL_RTC_GetDate(&hrtc, &date, RTC_FORMAT_BIN);
@@ -117,14 +117,14 @@ uint32_t RtcGetEpoch(void)
  * @param time   Pointer to a RTC time structure where the converted values are
  *               written.
  */
-void RtcConvertEpochToDatetime(uint32_t         epoch,
+void RtcConvertEpochToDatetime(uint32_t epoch,
                                RTC_DateTypeDef* date,
                                RTC_TimeTypeDef* time)
 {
     assert_param(date != NULL);
     assert_param(time != NULL);
 
-    time_t    rawTime  = (time_t)epoch;
+    time_t rawTime     = (time_t)epoch;
     struct tm dateTime = *localtime(&rawTime);
 
     date->Year  = dateTime.tm_year - 100U;
@@ -148,10 +148,10 @@ void RtcConvertEpochToDatetime(uint32_t         epoch,
  */
 uint8_t RtcSetAlarmFromEpoch(const uint32_t epoch)
 {
-    static RTC_DateTypeDef  date   = {0U};
-    static RTC_TimeTypeDef  time   = {0U};
+    static RTC_DateTypeDef date    = {0U};
+    static RTC_TimeTypeDef time    = {0U};
     static RTC_AlarmTypeDef sAlarm = {0U};
-    uint8_t                 result = 0U;
+    uint8_t result                 = 0U;
 
     /* Allow alarms to be set only in the future */
     if(epoch > RtcGetEpoch())

--- a/source/stm32l4xx_hal_timebase.c
+++ b/source/stm32l4xx_hal_timebase.c
@@ -32,11 +32,11 @@ TIM_HandleTypeDef htim17;
  */
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority)
 {
-    HAL_StatusTypeDef  result;
+    HAL_StatusTypeDef result;
     RCC_ClkInitTypeDef rccClockConfig = {0U};
-    uint32_t           clockFrequency = 0U;
-    uint32_t           clockPrescaler = 0U;
-    uint32_t           flashLatency;
+    uint32_t clockFrequency           = 0U;
+    uint32_t clockPrescaler           = 0U;
+    uint32_t flashLatency;
 
     /* Set the global tick interrupt priority variable */
     uwTickPrio = TickPriority;

--- a/source/system_stm32l4xx.c
+++ b/source/system_stm32l4xx.c
@@ -151,9 +151,9 @@
 */
 uint32_t SystemCoreClock = 4000000U;
 
-const uint8_t  AHBPrescTable[16] = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
+const uint8_t AHBPrescTable[16]  = {0U, 0U, 0U, 0U, 0U, 0U, 0U, 0U,
                                    1U, 2U, 3U, 4U, 6U, 7U, 8U, 9U};
-const uint8_t  APBPrescTable[8]  = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
+const uint8_t APBPrescTable[8]   = {0U, 0U, 0U, 0U, 1U, 2U, 3U, 4U};
 const uint32_t MSIRangeTable[12] = {100000U,   200000U,   400000U,   800000U,
                                     1000000U,  2000000U,  4000000U,  8000000U,
                                     16000000U, 24000000U, 32000000U, 48000000U};


### PR DESCRIPTION
## Description
This PR adjusts the `.clang-format` rules:
- Set the `AlignConsecutiveDeclarations` to `false`
- Increase `PenaltyReturnTypeOnItsOwnLine` to `200` to prevent putting function definitions and declarations with multiple arguments on new line
- Set `SpacesBeforeTrailingComments` to `2`

## Related issues / pull requests

Closes #11 
