### PR TITLE
Add tools list to SCons environment

### DIFF
--- a/projects/GCC/SConscript
+++ b/projects/GCC/SConscript
@@ -86,6 +86,7 @@ sources += Glob('startup_stm32l496xx.s')
 
 # Create environment
 env = Environment(
+    tools=('as', 'ar', 'gcc', 'g++', 'gnulink'),
     ENV={'PATH': os.environ['PATH']}
 )
 


### PR DESCRIPTION
## Description

On Windows if the PATH is populated with multiple build tools, SCons might set the wrong construction variables by default if the tools list is not specified.

## Related issues / pull requests

None.
